### PR TITLE
Make globals available to macros

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import lodash from 'lodash'
 import nunjucks from 'nunjucks'
 import {
     getPackageInfo,
-    merge, normalizePath,
+    merge,
     pluginBundle,
     pluginMiddleware,
     pluginReload,
@@ -23,7 +23,8 @@ const defaultOptions = {
     root: null,
     filters: {},
     extensions: {},
-    globals: {
+    globals: {},
+    context: {
         format: 'njk'
     },
     data: ['src/data/**/*.json'],
@@ -39,8 +40,8 @@ const renderTemplate = async ({ filename, server, resolvedConfig }, content, opt
         ? processData({
             paths: options.data,
             root: resolvedConfig.root
-        }, options.globals)
-        : options.globals
+        }, options.context)
+        : options.context
 
     if (initialFilename.endsWith('.json')) {
         lodash.merge(context, JSON.parse(content))
@@ -78,6 +79,10 @@ const renderTemplate = async ({ filename, server, resolvedConfig }, content, opt
         }
 
         nunjucksEnvironment.addFilter(name, options.filters[name])
+    })
+
+    Object.keys(options.globals).forEach(name => {
+        nunjucksEnvironment.addGlobal(name, options.globals[name])
     })
 
     Object.keys(options.extensions).forEach(name => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,7 +30,8 @@ export interface PluginUserConfig {
     root?: string
     filters?: Object
     extensions?: Object
-    globals?: Object
+    globals?: Object,
+    context?: Object,
     data?: string | string[]
     formats?: string[]
     ignoredPaths?: string[]


### PR DESCRIPTION
Implements the first of the two provided options to fix #5:

- Property 'globals' will be renamed to 'context'.
- The new 'globals' will be available to macros as well.